### PR TITLE
ADL Theme Color Defaults

### DIFF
--- a/app/assets/stylesheets/adl-overrides/adl-overrides.scss
+++ b/app/assets/stylesheets/adl-overrides/adl-overrides.scss
@@ -420,6 +420,7 @@ body.adventist_digital_library {
   li.dropdown-item {
     padding: 10px;
     width: 200px;
+    font-size: 100%;
   }
 
   // FORMS
@@ -520,4 +521,17 @@ body.works-show.adl_show {
 .title-with-badges span.badge,
 .collection-title-row-content span.badge {
   display: none;
+}
+
+// adds background to collection banner text items so they don't disappear on the background
+.hyc-banner {
+  .hyc-bugs {
+    .hyc-created-by,
+    .hyc-last-updated {
+      background: rgba(255, 255, 255, 0.75);
+      border-radius: 0.5em;
+      color: #333;
+      padding: 1px;
+    }
+  }
 }

--- a/config/home_themes.yml
+++ b/config/home_themes.yml
@@ -18,6 +18,21 @@ adventist_digital_library:
   marketing_text: true
   name: Adventist Digital Library
   notes: This theme is recomended for the Adventist Digital Library
+  theme_custom_colors:
+    collection_banner_text_color: '#000000'
+    default_button_background_color: '#FFFFFF'
+    default_button_border_color: '#5B5B5B'
+    default_button_text_color: '#CE8C00'
+    facet_panel_background_color: '#FFFFFF'
+    facet_panel_text_color: '#985F03'
+    footer_link_color: '#985F03'
+    header_and_footer_text_color: '#985F03'
+    link_color: '#985F03'
+    link_hover_color: '#FFBD42'
+    primary_button_background_color: '#FFFFFF'
+    primary_button_border_color: '#CE8C00'
+    primary_button_hover_color: '#215480'
+    primary_button_text_color: '#985F03'
 cultural_repository:
   banner_image: true
   featured_researcher: false


### PR DESCRIPTION
# Story

Refs 
- https://github.com/notch8/adventist_knapsack/issues/914
- https://github.com/notch8/adventist_knapsack/pull/915
- https://github.com/samvera/hyku/pull/2456

Custom color overrides broke a lot of the appearance color menu behavior. Those overrides were removed, and a new way of setting a default color grouping for a theme was added to hyku.

The changes here implement this new feature of setting default colors for a theme.

# Expected Behavior Before Changes

Appearance colors had to be set individually for a theme.

# Expected Behavior After Changes

If a theme has custom colors available, a button will show on the appearance colors menu to allow a simple way to default to the theme's colors.

# Screenshots / Video

<details>
<summary>Video</summary>

[recorded (1).webm](https://github.com/user-attachments/assets/4f5c23e0-9e54-4a57-9b97-f118e6781e08)

</details>

# Notes
