### PR TITLE
…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,9 +20,6 @@ x-app: &app
     - GOOD_JOB_CLEANUP_DISCARDED_JOBS=false
     - GOOD_JOB_CLEANUP_INTERVAL_SECONDS=86400
     - GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO=604800
-    - HYKU_ADMIN_HOST=adl.test
-    - HYKU_DEFAULT_HOST=%{tenant}.adl.test
-    - HYKU_ROOT_HOST=adl.test
     - HYRAX_ACTIVE_JOB_QUEUE=good_job
   volumes:
     - node_modules:/app/samvera/hyrax-webapp/node_modules:cached
@@ -32,8 +29,6 @@ x-app: &app
     - .:/app/samvera
   env_file:
     - .env
-  networks:
-    internal:
 
 x-app-worker: &app-worker
     <<: *app
@@ -81,9 +76,17 @@ volumes:
   zoo:
 
 networks:
-  internal:
+  default:
+    name: stackcar
 
 services:
+  adminer:
+    extends:
+      file: hyrax-webapp/docker-compose.yml
+      service: adminer
+    environment:
+      - VIRTUAL_PORT=8080
+      - VIRTUAL_HOST=admin-hyku.localhost.direct
   zoo:
     extends:
       file: hyrax-webapp/docker-compose.yml
@@ -103,8 +106,6 @@ services:
     image: harvardlts/fitsservlet_container:1.5.0
     ports:
       - 9090:8080
-    networks:
-      internal:
 
   db:
     extends:
@@ -134,12 +135,7 @@ services:
       - GOOD_JOB_CLEANUP_DISCARDED_JOBS=false
       - GOOD_JOB_CLEANUP_INTERVAL_SECONDS=86400
       - GOOD_JOB_CLEANUP_PRESERVED_JOBS_BEFORE_SECONDS_AGO=604800
-      - HYKU_ADMIN_HOST=adl.test
-      - HYKU_DEFAULT_HOST=%{tenant}.adl.test
-      - HYKU_ROOT_HOST=adl.test
       - HYRAX_ACTIVE_JOB_QUEUE=good_job
-      - VIRTUAL_HOST=.adl.test
-      - VIRTUAL_PORT=3000
 
     depends_on:
       db:


### PR DESCRIPTION
Update to be inline with hyku main which add traefix proxy with stack_car gem, see instructions in the hyku [docs/getting-started.md](https://github.com/samvera/hyku/blob/main/docs/getting-started.md#installation) under the `Set up DNS:` section. 

pw: `localhost`

```bash
gem install stack_car
sc proxy cert
sc proxy up
```

Now that you have your proxy running (equivalent to dory up but sc proxy up), when you get docker running with docker compose build, if you image isn't built yet and then docker compose up
Navigate to the admin hyku tenant at: https://admin-hyku.localhost.direct
When you make a tenant, ex: demo, you will then append`-hyku.localhost.direct` to the tenant name so the url would be `demo-hyku.localhost.direct`
