### PR TITLE
Use PDF.js

### DIFF
--- a/app/helpers/pdf_js_helper_decorator.rb
+++ b/app/helpers/pdf_js_helper_decorator.rb
@@ -48,6 +48,13 @@ module PdfJsHelperDecorator
 
     "search=#{q}&phrase=true"
   end
+
+  # overide the default behavior to deactivate checkboxes.
+  # They do not seem to work for the work types defined in Hyrax or Hyku
+  # and are preventing the PDF.js viewer from displaying.
+  def render_show_pdf_behavior_checkbox?
+    false
+  end
 end
 
 PdfJsHelper.prepend(PdfJsHelperDecorator)


### PR DESCRIPTION
# Story

Removes some of custom logic for when to use universal viewer. Even if a work has been split to child works it now uses the pdf.js viewer if that is the setting.

Some overrides still exist, to allow the viewer to display for either a url or an attached file.

The pdf.js viewer retains the override to not respect the checkbox to not show the viewer. This is a problematic option, because it wasn't correctly initializing to checked in all cases. Until this can be resolved, the options are hidden.

Refs https://github.com/notch8/adventist_knapsack/issues/939

# Expected Behavior Before Changes

If a pdf is split into child works the Universal Viewer shows regardless of setting.

# Expected Behavior After Changes

If pdf.js viewer is selected, the pdf.js viewer will show if the representative file is set to be the pdf. (This can be modified by editing the work). 
The universal viewer will still be used for appropriate file types.

# Notes
