### PR TITLE
Add fallback method to find filesets

### DIFF
--- a/app/presenters/hyrax/pcdm_member_presenter_factory_decorator.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory_decorator.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+# Override Hyrax branch main_before_rails_72 to find old filesets which don't include generic_type index term.
+# Can be removed once all filesets are updated.
+
+module Hyrax
+  module PcdmMemberPresenterFactoryDecorator
+    private
+
+    def query_docs(generic_type: nil, ids: object.member_ids)
+      docs = super
+      return docs unless docs.empty?
+
+      Rails.logger.info "Fallback query: no fileset docs found for work #{object.slug}"
+
+      query = "{!terms f=id}#{ids.join(',')}"
+      query += "{!term f=has_model_ssim}#{generic_type}" if generic_type
+
+      Hyrax::SolrService
+        .post(q: query, rows: 10_000)
+        .fetch('response')
+        .fetch('docs')
+    end
+  end
+end
+
+Hyrax::PcdmMemberPresenterFactory.prepend Hyrax::PcdmMemberPresenterFactoryDecorator


### PR DESCRIPTION
# Story

In a number of cases, unmigrated works are showing a thumbnail rather than an image viewer. 

# Expected Behavior Before Changes

Old & unmigrated work shows a thumbnail, but shows viewer once migration happens.
No option to set/change a representative or thumbnail in the work's edit view.

# Expected Behavior After Changes

Unmigrated works show appropriate viewer.
Able to update representative image & thumbnail on the work edit page.

# Screenshots / Video

<details>
<summary>Example work in staging</summary>

Previously showed only thumbnail image, with no option to change in edit.
https://adl.s2.adventistdigitallibrary.org/concern/published_works/f87149de-4e66-4f36-88d7-2a10a7cdd947

Before:
![Screenshot 2025-04-17 at 10 18 18 PM](https://github.com/user-attachments/assets/37b9df31-9256-4037-ba0d-89cd6a358b62)

</details>

# Notes
