### PR TITLE
Child works should be able to have slugs

### DIFF
--- a/app/models/solr_document_decorator.rb
+++ b/app/models/solr_document_decorator.rb
@@ -44,6 +44,7 @@ module AdlSolrDocumentDecorator
 
   # Keep these alphebetized; comments indicate those in basic_metadata
   #   see https://github.com/samvera/hyrax/blob/master/app/models/concerns/hyrax/solr_document/metadata.rb
+  # rubocop:disble Metrics/AbcSize, Metrics/MethodLength
   def self.prepended(base)
     base.attribute :abstract, Solr::Array, base.solr_name('abstract')
     base.attribute :access_provided_by, Solr::Array, base.solr_name('access_provided_by')
@@ -161,6 +162,7 @@ module AdlSolrDocumentDecorator
       type: 'human_readable_type_tesim'
     )
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
   # @return [Array<SolrDocument>] a list of solr documents in no particular order
   def load_parent_docs

--- a/app/models/solr_document_decorator.rb
+++ b/app/models/solr_document_decorator.rb
@@ -166,7 +166,7 @@ module AdlSolrDocumentDecorator
 
   # @return [Array<SolrDocument>] a list of solr documents in no particular order
   def load_parent_docs
-    # in case the id is a slug, we have to convert it to an id bexause memberships are stored as ids
+    # in case the id is a slug, we have to convert it to an id because memberships are stored as ids
     new_id = self["resource_id_ssi"] || self["fedora_id_ssi"] || id
 
     query("member_ids_ssim:#{new_id}", rows: 1000)

--- a/app/models/solr_document_decorator.rb
+++ b/app/models/solr_document_decorator.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 module AdlSolrDocumentDecorator
-  extend ActiveSupport::Concern
-  class_methods do
+  module ClassMethods
     def attribute(name, type, field)
       define_method name do
         type.coerce(self[field])
@@ -45,108 +44,108 @@ module AdlSolrDocumentDecorator
 
   # Keep these alphebetized; comments indicate those in basic_metadata
   #   see https://github.com/samvera/hyrax/blob/master/app/models/concerns/hyrax/solr_document/metadata.rb
-  included do
-    attribute :abstract, Solr::Array, solr_name('abstract')
-    attribute :access_provided_by, Solr::Array, solr_name('access_provided_by')
-    attribute :advisor, Solr::Array, solr_name('advisor')
-    attribute :alt, Solr::Array, solr_name('alt')
-    attribute :awarding_institution, Solr::Array, solr_name('awarding_institution')
+  def self.prepended(base)
+    base.attribute :abstract, Solr::Array, base.solr_name('abstract')
+    base.attribute :access_provided_by, Solr::Array, base.solr_name('access_provided_by')
+    base.attribute :advisor, Solr::Array, base.solr_name('advisor')
+    base.attribute :alt, Solr::Array, base.solr_name('alt')
+    base.attribute :awarding_institution, Solr::Array, base.solr_name('awarding_institution')
     # based_near and based_near
-    attribute :content_version, Solr::Array, solr_name('content_version')
+    base.attribute :content_version, Solr::Array, base.solr_name('content_version')
     # contributor
     # creator
-    attribute :date, Solr::Array, solr_name('date')
-    attribute :date_accepted, Solr::Array, solr_name('date_accepted')
-    attribute :date_available, Solr::Array, solr_name('date_available')
-    attribute :date_collected, Solr::Array, solr_name('date_collected')
-    attribute :date_copyrighted, Solr::Array, solr_name('date_copyrighted')
-    attribute :date_issued, Solr::Array, solr_name('date_issued')
+    base.attribute :date, Solr::Array, base.solr_name('date')
+    base.attribute :date_accepted, Solr::Array, base.solr_name('date_accepted')
+    base.attribute :date_available, Solr::Array, base.solr_name('date_available')
+    base.attribute :date_collected, Solr::Array, base.solr_name('date_collected')
+    base.attribute :date_copyrighted, Solr::Array, base.solr_name('date_copyrighted')
+    base.attribute :date_issued, Solr::Array, base.solr_name('date_issued')
     # date_created
-    attribute :date_of_award, Solr::Array, solr_name('date_of_award')
-    attribute :date_published, Solr::Array, solr_name('date_published')
-    attribute :date_submitted, Solr::Array, solr_name('date_submitted')
-    attribute :date_updated, Solr::Array, solr_name('date_updated')
-    attribute :date_valid, Solr::Array, solr_name('date_valid')
-    attribute :dc_access_rights, Solr::Array, solr_name('dc_access_rights')
-    attribute :department, Solr::Array, solr_name('department')
+    base.attribute :date_of_award, Solr::Array, base.solr_name('date_of_award')
+    base.attribute :date_published, Solr::Array, base.solr_name('date_published')
+    base.attribute :date_submitted, Solr::Array, base.solr_name('date_submitted')
+    base.attribute :date_updated, Solr::Array, base.solr_name('date_updated')
+    base.attribute :date_valid, Solr::Array, base.solr_name('date_valid')
+    base.attribute :dc_access_rights, Solr::Array, base.solr_name('dc_access_rights')
+    base.attribute :department, Solr::Array, base.solr_name('department')
     # description
-    attribute :doi, Solr::Array, solr_name('doi')
-    attribute :edition, Solr::Array, solr_name('edition')
-    attribute :editor, Solr::Array, solr_name('editor')
-    attribute :end_date, Solr::Array, solr_name('end_date')
-    attribute :event_date, Solr::Array, solr_name('event_date')
-    attribute :extent, Solr::Array, solr_name('extent')
-    attribute :dc_format, Solr::Array, solr_name('dc_format')
-    attribute :former_identifier, Solr::Array, solr_name('former_identifier')
-    attribute :funder, Solr::Array, solr_name('funder')
-    attribute :resource_type_general, Solr::Array, solr_name('resource_type_general')
-    attribute :has_restriction, Solr::Array, solr_name('has_restriction')
+    base.attribute :doi, Solr::Array, base.solr_name('doi')
+    base.attribute :edition, Solr::Array, base.solr_name('edition')
+    base.attribute :editor, Solr::Array, base.solr_name('editor')
+    base.attribute :end_date, Solr::Array, base.solr_name('end_date')
+    base.attribute :event_date, Solr::Array, base.solr_name('event_date')
+    base.attribute :extent, Solr::Array, base.solr_name('extent')
+    base.attribute :dc_format, Solr::Array, base.solr_name('dc_format')
+    base.attribute :former_identifier, Solr::Array, base.solr_name('former_identifier')
+    base.attribute :funder, Solr::Array, base.solr_name('funder')
+    base.attribute :resource_type_general, Solr::Array, base.solr_name('resource_type_general')
+    base.attribute :has_restriction, Solr::Array, base.solr_name('has_restriction')
     # rubocop:enable Naming/PredicateName
 
     # identifier
-    attribute :isbn, Solr::Array, solr_name('isbn')
-    attribute :issue_number, Solr::Array, solr_name('issue_number')
+    base.attribute :isbn, Solr::Array, base.solr_name('isbn')
+    base.attribute :issue_number, Solr::Array, base.solr_name('issue_number')
     # keyword
     # language
-    attribute :last_access, Solr::Array, solr_name('last_access')
-    attribute :lat, Solr::Array, solr_name('lat')
+    base.attribute :last_access, Solr::Array, base.solr_name('last_access')
+    base.attribute :lat, Solr::Array, base.solr_name('lat')
     # license
-    attribute :location, Solr::Array, solr_name('location')
-    attribute :long, Solr::Array, solr_name('long')
-    attribute :managing_organisation, Solr::Array, solr_name('managing_organisation')
-    attribute :module_code, Solr::Array, solr_name('module_code')
-    attribute :note, Solr::Array, solr_name('note')
-    attribute :number_of_downloads, Solr::Array, solr_name('last_access')
-    attribute :official_url, Solr::Array, solr_name('official_url')
-    attribute :output_of, Solr::Array, solr_name('output_of')
-    attribute :official_url, Solr::Array, solr_name('official_url')
-    attribute :packaged_by_ids, Solr::Array, solr_name('packaged_by_ids', :symbol)
-    attribute :package_ids, Solr::Array, solr_name('package_ids', :symbol)
-    attribute :pagination, Solr::Array, solr_name('pagination')
-    attribute :part, Solr::Array, solr_name('part')
-    attribute :place_of_publication, Solr::Array, solr_name('place_of_publication')
-    attribute :presented_at, Solr::Array, solr_name('presented_at')
-    attribute :part_of, Solr::Array, solr_name('part_of')
-    attribute :project, Solr::Array, solr_name('project')
-    attribute :publication_status, Solr::Array, solr_name('publication_status')
+    base.attribute :location, Solr::Array, base.solr_name('location')
+    base.attribute :long, Solr::Array, base.solr_name('long')
+    base.attribute :managing_organisation, Solr::Array, base.solr_name('managing_organisation')
+    base.attribute :module_code, Solr::Array, base.solr_name('module_code')
+    base.attribute :note, Solr::Array, base.solr_name('note')
+    base.attribute :number_of_downloads, Solr::Array, base.solr_name('last_access')
+    base.attribute :official_url, Solr::Array, base.solr_name('official_url')
+    base.attribute :output_of, Solr::Array, base.solr_name('output_of')
+    base.attribute :official_url, Solr::Array, base.solr_name('official_url')
+    base.attribute :packaged_by_ids, Solr::Array, base.solr_name('packaged_by_ids', :symbol)
+    base.attribute :package_ids, Solr::Array, base.solr_name('package_ids', :symbol)
+    base.attribute :pagination, Solr::Array, base.solr_name('pagination')
+    base.attribute :part, Solr::Array, base.solr_name('part')
+    base.attribute :place_of_publication, Solr::Array, base.solr_name('place_of_publication')
+    base.attribute :presented_at, Solr::Array, base.solr_name('presented_at')
+    base.attribute :part_of, Solr::Array, base.solr_name('part_of')
+    base.attribute :project, Solr::Array, base.solr_name('project')
+    base.attribute :publication_status, Solr::Array, base.solr_name('publication_status')
     # publisher
-    attribute :qualification_level, Solr::Array, solr_name('qualification_level')
-    attribute :qualification_name, Solr::Array, solr_name('qualification_name')
-    attribute :refereed, Solr::Array, solr_name('refereed')
-    attribute :related_url, Solr::Array, solr_name('related_url')
+    base.attribute :qualification_level, Solr::Array, base.solr_name('qualification_level')
+    base.attribute :qualification_name, Solr::Array, base.solr_name('qualification_name')
+    base.attribute :refereed, Solr::Array, base.solr_name('refereed')
+    base.attribute :related_url, Solr::Array, base.solr_name('related_url')
     # resource_type
     # rights_statement
-    attribute :series, Solr::Array, solr_name('series')
+    base.attribute :series, Solr::Array, base.solr_name('series')
     # source
-    attribute :start_date, Solr::Array, solr_name('start_date')
+    base.attribute :start_date, Solr::Array, base.solr_name('start_date')
     # subject
-    attribute :subtitle, Solr::Array, solr_name('subtitle')
-    attribute :volume_number, Solr::Array, solr_name('volume_number')
+    base.attribute :subtitle, Solr::Array, base.solr_name('subtitle')
+    base.attribute :volume_number, Solr::Array, base.solr_name('volume_number')
     # archivematica
-    attribute :aip_uuid, Solr::Array, solr_name('aip_uuid')
-    attribute :transfer_uuid, Solr::Array, solr_name('transfer_uuid')
-    attribute :sip_uuid, Solr::Array, solr_name('sip_uuid')
-    attribute :dip_uuid, Solr::Array, solr_name('dip_uuid')
-    attribute :aip_status, Solr::Array, solr_name('aip_status')
-    attribute :dip_status, Solr::Array, solr_name('dip_status')
-    attribute :aip_size, Solr::Array, solr_name('aip_size')
-    attribute :dip_size, Solr::Array, solr_name('dip_size')
-    attribute :aip_current_path, Solr::Array, solr_name('aip_current_path')
-    attribute :dip_current_path, Solr::Array, solr_name('dip_current_path')
-    attribute :aip_current_location, Solr::Array, solr_name('aip_current_location')
-    attribute :dip_current_location, Solr::Array, solr_name('dip_current_location')
-    attribute :aip_resource_uri, Solr::Array, solr_name('aip_resource_uri')
-    attribute :dip_resource_uri, Solr::Array, solr_name('dip_resource_uri')
-    attribute :origin_pipeline, Solr::Array, solr_name('origin_pipeline')
-    attribute :slug, Solr::String, 'slug_tesim'
-    attribute :fedora_id, Solr::String, 'fedora_id_ssi'
-    attribute :aark_id, Solr::String, 'aark_id_tesim'
-    attribute :bibliographic_citation, Solr::String, 'bibliographic_citation_tesim'
-    attribute :alt, Solr::String, 'alt_tesim'
-    attribute :file_set_ids, Solr::Array, 'file_set_ids_ssim'
-    attribute :video_embed, Solr::String, 'video_embed_tesim'
+    base.attribute :aip_uuid, Solr::Array, base.solr_name('aip_uuid')
+    base.attribute :transfer_uuid, Solr::Array, base.solr_name('transfer_uuid')
+    base.attribute :sip_uuid, Solr::Array, base.solr_name('sip_uuid')
+    base.attribute :dip_uuid, Solr::Array, base.solr_name('dip_uuid')
+    base.attribute :aip_status, Solr::Array, base.solr_name('aip_status')
+    base.attribute :dip_status, Solr::Array, base.solr_name('dip_status')
+    base.attribute :aip_size, Solr::Array, base.solr_name('aip_size')
+    base.attribute :dip_size, Solr::Array, base.solr_name('dip_size')
+    base.attribute :aip_current_path, Solr::Array, base.solr_name('aip_current_path')
+    base.attribute :dip_current_path, Solr::Array, base.solr_name('dip_current_path')
+    base.attribute :aip_current_location, Solr::Array, base.solr_name('aip_current_location')
+    base.attribute :dip_current_location, Solr::Array, base.solr_name('dip_current_location')
+    base.attribute :aip_resource_uri, Solr::Array, base.solr_name('aip_resource_uri')
+    base.attribute :dip_resource_uri, Solr::Array, base.solr_name('dip_resource_uri')
+    base.attribute :origin_pipeline, Solr::Array, base.solr_name('origin_pipeline')
+    base.attribute :slug, Solr::String, 'slug_tesim'
+    base.attribute :fedora_id, Solr::String, 'fedora_id_ssi'
+    base.attribute :aark_id, Solr::String, 'aark_id_tesim'
+    base.attribute :bibliographic_citation, Solr::String, 'bibliographic_citation_tesim'
+    base.attribute :alt, Solr::String, 'alt_tesim'
+    base.attribute :file_set_ids, Solr::Array, 'file_set_ids_ssim'
+    base.attribute :video_embed, Solr::String, 'video_embed_tesim'
 
-    field_semantics.merge!(
+    base.field_semantics.merge!(
       contributor: 'contributor_tesim',
       creator: 'creator_tesim',
       date: 'date_created_tesim',
@@ -163,6 +162,15 @@ module AdlSolrDocumentDecorator
     )
   end
 
+  # @return [Array<SolrDocument>] a list of solr documents in no particular order
+  def load_parent_docs
+    # in case the id is a slug, we have to convert it to an id bexause memberships are stored as ids
+    new_id = self["resource_id_ssi"] || self["fedora_id_ssi"] || id
+
+    query("member_ids_ssim:#{new_id}", rows: 1000)
+      .map { |res| ::SolrDocument.new(res) }
+  end
+
   def to_param
     slug || id.to_s
   end
@@ -176,4 +184,5 @@ module AdlSolrDocumentDecorator
   end
 end
 
-SolrDocument.include(AdlSolrDocumentDecorator)
+SolrDocument.singleton_class.prepend(AdlSolrDocumentDecorator::ClassMethods)
+SolrDocument.prepend(AdlSolrDocumentDecorator)

--- a/app/models/solr_document_decorator.rb
+++ b/app/models/solr_document_decorator.rb
@@ -44,7 +44,7 @@ module AdlSolrDocumentDecorator
 
   # Keep these alphebetized; comments indicate those in basic_metadata
   #   see https://github.com/samvera/hyrax/blob/master/app/models/concerns/hyrax/solr_document/metadata.rb
-  # rubocop:disble Metrics/AbcSize, Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def self.prepended(base)
     base.attribute :abstract, Solr::Array, base.solr_name('abstract')
     base.attribute :access_provided_by, Solr::Array, base.solr_name('access_provided_by')

--- a/app/presenters/hyrax/pcdm_member_presenter_factory_decorator.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory_decorator.rb
@@ -1,24 +1,60 @@
 # frozen_string_literal: true
-# Override Hyrax branch main_before_rails_72 to find old filesets which don't include generic_type index term.
-# Can be removed once all filesets are updated.
+# Override Hyrax branch main_before_rails_72
+# - find old filesets which don't include generic_type index term.
+# - find members using resource_id_ssi or id to support child works
 
 module Hyrax
   module PcdmMemberPresenterFactoryDecorator
+    def member_presenters(ids = object.member_ids)
+      return enum_for(:member_presenters, ids).to_a unless block_given?
+
+      results = query_docs(ids: ids)
+
+      ids.each do |id|
+        id = id.to_s
+        indx = results.index { |doc| id == doc['resource_id_ssi'] || id == doc['fedora_id_ssi'] || id == doc['id'] }
+        raise(Hyrax::ObjectNotFoundError, "Could not find an indexed document for id: #{id}") if
+          indx.nil?
+        hash = results.delete_at(indx)
+        yield presenter_for(document: ::SolrDocument.new(hash), ability: ability)
+      end
+    end
+
     private
 
     def query_docs(generic_type: nil, ids: object.member_ids)
-      docs = super
-      return docs unless docs.empty?
+      case generic_type
+      when "FileSet"
+        docs = super
+        return docs unless docs.empty?
+        # Fallback to Solr query for older filesets that don't have generic_type index term
+        # This can be removed once all filesets are migrated
+        Rails.logger.info "Fallback query: no fileset docs found for work #{object.to_param}, looking by model"
+        find_by_model(generic_type:, ids:)
+      else
+        query_works(ids:)
+      end
+    end
 
-      Rails.logger.info "Fallback query: no fileset docs found for work #{object.slug}"
-
+    def find_by_model(generic_type:, ids:)
       query = "{!terms f=id}#{ids.join(',')}"
-      query += "{!term f=has_model_ssim}#{generic_type}" if generic_type
+      query += "{!term f=has_model_ssim}#{generic_type}"
 
       Hyrax::SolrService
         .post(q: query, rows: 10_000)
         .fetch('response')
         .fetch('docs')
+    end
+
+    # Query for works using resource_id_ssi or fedora_id_ssi to support slugs
+    def query_works(ids:)
+      terms = ids.map { |id| "\"#{id}\"" }.join(' ')
+      query = "(id:(#{terms}) OR resource_id_ssi:(#{terms}) OR fedora_id_ssi:(#{terms}))"
+
+      Hyrax::SolrService
+      .post(fq: query, rows: 10_000)
+      .fetch('response')
+      .fetch('docs')
     end
   end
 end

--- a/app/presenters/hyrax/pcdm_member_presenter_factory_decorator.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory_decorator.rb
@@ -48,6 +48,7 @@ module Hyrax
 
     # Query for works using resource_id_ssi or fedora_id_ssi to support slugs
     def query_works(ids:)
+      return [] if ids.empty?
       terms = ids.map { |id| "\"#{id}\"" }.join(' ')
       query = "(id:(#{terms}) OR resource_id_ssi:(#{terms}) OR fedora_id_ssi:(#{terms}))"
 

--- a/app/presenters/hyrax/pcdm_member_presenter_factory_decorator.rb
+++ b/app/presenters/hyrax/pcdm_member_presenter_factory_decorator.rb
@@ -8,7 +8,7 @@ module Hyrax
     def member_presenters(ids = object.member_ids)
       return enum_for(:member_presenters, ids).to_a unless block_given?
 
-      results = query_docs(ids: ids)
+      results = query_docs(ids:)
 
       ids.each do |id|
         id = id.to_s
@@ -16,7 +16,7 @@ module Hyrax
         raise(Hyrax::ObjectNotFoundError, "Could not find an indexed document for id: #{id}") if
           indx.nil?
         hash = results.delete_at(indx)
-        yield presenter_for(document: ::SolrDocument.new(hash), ability: ability)
+        yield presenter_for(document: ::SolrDocument.new(hash), ability:)
       end
     end
 
@@ -52,9 +52,9 @@ module Hyrax
       query = "(id:(#{terms}) OR resource_id_ssi:(#{terms}) OR fedora_id_ssi:(#{terms}))"
 
       Hyrax::SolrService
-      .post(fq: query, rows: 10_000)
-      .fetch('response')
-      .fetch('docs')
+        .post(fq: query, rows: 10_000)
+        .fetch('response')
+        .fetch('docs')
     end
   end
 end


### PR DESCRIPTION
# Story

Creating child works with slugs did not correctly build and display the works and relationships. Creating through the UI did not show the relationships, but creating through Bulkrax did not work at all.

Member relationships use the object's id. However the solr document is indexed with the slug as the id. We have to ensure that we search the appropriate terms in the solr document when we are searching by id.

This commit fixes two aspects of child works with slugs:
1. It ensures that a work can find its child works with slugs.
2. It ensures that a work with slugs can find its parent work.

This preparation is needed before [bulkrax relationship fixes](https://github.com/samvera/bulkrax/pull/1028) are incorporated into the application, as they would break the UI if they used slugs.

Note: The AdlSolrDocumentDecorator required refactoring in order to use `prepend` to have the instance method override Hyrax's SolrDocument. Previously methods were added via `include`, and nothing was overridden.

# Expected Behavior Before Changes

When creating a child work with a slug in the UI, the relationship was not shown.
Child works and parent works could not form relationships through Bulkrax.

# Expected Behavior After Changes

Parent works include child works both with and without slugs in the items list.
Child works with slugs show their parent work in the relationships section.
Filesets still show correctly as part of the work in the items list.

# Screenshots / Video

<details>
<summary>Work with 2 child works</summary>

This is a work that has a slugs. It has two child works, one with a slug and one with a UUID. It also has a fileset. It correctly finds its parent work which also has a slug.

![Screenshot 2025-04-19 at 4 56 09 PM](https://github.com/user-attachments/assets/c0621fd3-6434-4997-943a-e847961315b8)

</details>

# Notes