### PR TITLE
Up job priority for Hyrax::QueuedIndexingJob

### DIFF
--- a/app/jobs/application_job_decorator.rb
+++ b/app/jobs/application_job_decorator.rb
@@ -25,7 +25,7 @@ module ApplicationJobDecorator
                        calculate_priority base: 40
                      when  CharacterizeJob
                        calculate_priority base: 30
-                     when  Hyrax::GrantEditToMembersJob, ImportUrlJob, IngestJob
+                     when  Hyrax::GrantEditToMembersJob, ImportUrlJob, IngestJob, Hyrax::QueuedIndexingJob
                        calculate_priority base: 10
                      when  AttachFilesToWorkJob
                        calculate_priority base: -1


### PR DESCRIPTION
By default, the Hyrax::QueuedIndexingJob is set to a priority of 0. Along with the number of jobs handled before rescheduling and the delay between jobs, this can result in the queue getting too backed up.

Upping the priority higher than the migration jobs lets the indexing jobs jump ahead and prevents them from getting stuck behind the migration jobs which were scheduled earlier.

