### PR TITLE
Submodule update for queued-indexer testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "hyrax-webapp"]
 	path = hyrax-webapp
 	url = https://github.com/samvera/hyku.git
+	branch = fix-file-set-pdf-indexing-bug


### PR DESCRIPTION
# Story

Refs https://github.com/samvera/hyku/pull/2538

Queued indexing failed on a Bulkrax import due to the work failing to find the file set in solr. 

# Expected Behavior Before Changes

Indexing job failed when worker uses queued indexing. Bulkrax ingest appeared to complete normally but work is not accessible in the UI because work and file set are not indexed. File set and then work had to be indexed manually.

# Expected Behavior After Changes

Bulkrax ingest completes normally.

# Screenshots / Video

# Notes
