### PR TITLE
Update hyku

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "hyrax-webapp"]
 	path = hyrax-webapp
 	url = https://github.com/samvera/hyku.git
-	branch = fix-file-set-pdf-indexing-bug
+	branch = main

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -129,8 +129,6 @@ extraEnvVars: &envVars
     value: b2.adventistdigitallibrary.org
   - name: HYKU_ADMIN_ONLY_TENANT_CREATION
     value: "true"
-  - name: HYKU_ATTACK_RATE_THROTTLE_OFF
-    value: "true"
   - name: HYKU_ALLOW_SIGNUP
     value: "false"
   - name: HYKU_ATTACK_RATE_THROTTLE_OFF

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -129,8 +129,12 @@ extraEnvVars: &envVars
     value: b2.adventistdigitallibrary.org
   - name: HYKU_ADMIN_ONLY_TENANT_CREATION
     value: "true"
+  - name: HYKU_ATTACK_RATE_THROTTLE_OFF
+    value: "true"
   - name: HYKU_ALLOW_SIGNUP
     value: "false"
+  - name: HYKU_ATTACK_RATE_THROTTLE_OFF
+    value: "true"
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
   - name: HYKU_CONTACT_EMAIL


### PR DESCRIPTION
# Story
- revert to use Hyku main branch
- brings in bulkrax relationship fixes
- disables the rack attack throttling middleware

This includes a Bulkrax update to resolve relationships from getting lost in the CreateRelationshipsJob
It also moves Hyku back to a main branch - it had been using a different branch to bring in some changes needed for the batch indexing but that work is now merged. 

As part of this update, rack attack must be disabled until our setup corrctly supports it.