### PR TITLE
Catalog page faceted search

### DIFF
--- a/app/controllers/catalog_controller_decorator.rb
+++ b/app/controllers/catalog_controller_decorator.rb
@@ -58,11 +58,14 @@ CatalogController.configure_blacklight do |config|
   # later load the dog biscuits translations.
   HykuKnapsack::Engine.load_translations!
 
-  # @todo remove this and list index properties individually
-  index_props = DogBiscuits.config.index_properties.collect do |prop|
-    { prop => CatalogController.send(:index_options, prop, DogBiscuits.config.property_mappings[prop]) }
-  end
-  CatalogController.send(:add_index_field, config, index_props)
+  # [:title, :creator, :part_of, :date_issued, :subject, :source, :description]
+  config.add_index_field 'title_tesim', itemprop: 'name', if: :render_in_tenant?
+  config.add_index_field 'creator_tesim', itemprop: 'creator', link_to_facet: 'creator_sim', if: :render_in_tenant?
+  config.add_index_field 'part_of_tesim', itemprop: 'partOf', link_to_facet: 'part_of_sim'
+  config.add_index_field 'date_issued_tesim', itemprop: 'dateIssued', if: :render_in_tenant?
+  config.add_index_field 'subject_tesim', itemprop: 'about', link_to_facet: 'subject_sim', if: :render_in_tenant?
+  config.add_index_field 'source_tesim', link_to_facet: 'source_sim'
+  config.add_index_field 'description_tesim', itemprop: 'description', helper_method: :truncate_and_iconify_auto_link, if: :render_in_tenant?
   config.add_index_field 'based_near_label_tesim', itemprop: 'contentLocation', link_to_facet: 'based_near_label_sim'
 
   config.search_fields.delete('all_fields')

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -18,6 +18,7 @@ en:
           contributor_tesim: Contributor
           creator_tesim: Author
           date_created_tesim: Date Created
+          date_issued_tesim: Date Issued
           date_modified_dtsi: Date Modified
           date_uploaded_dtsi: Date Uploaded
           description_tesim: Description
@@ -26,8 +27,10 @@ en:
           identifier_tesim: Identifier
           keyword_tesim: Keyword
           language_tesim: Language
+          part_of_tesim: Part Of
           publisher_tesim: Publisher
           rights_tesim: Rights
+          source_tesim: Source
           subject_tesim: Subject
         show:
           based_near_label_tesim: Location

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,8 @@ x-app-worker: &app-worker
     args:
       BUILDKIT_INLINE_CACHE: 1
       APP_PATH: ./hyrax-webapp
+  environment:
+    - HYRAX_FLEXIBLE=false
   image: ghcr.io/notch8/adventist_knapsack/worker:${TAG:-latest}
   # Uncomment command to access container with out starting bin/worker. Useful for debugging or updating Gemfile.lock
   # command: sleep infinity
@@ -109,6 +111,8 @@ services:
 
   web:
     <<: *app
+    environment:
+      - HYRAX_FLEXIBLE=false
     extends:
       file: hyrax-webapp/docker-compose.yml
       service: web

--- a/spec/controllers/catalog_controller_decorator_spec.rb
+++ b/spec/controllers/catalog_controller_decorator_spec.rb
@@ -8,24 +8,6 @@ RSpec.describe CatalogController do
 
     its(:search_builder_class) { is_expected.to eq(AdvSearchBuilder) }
 
-    describe 'dog biscuits induced catalog translations' do
-      subject { blacklight_config.index_fields.fetch(given_field).label }
-
-      [
-        ["title_tesim", "Title"],
-        ["creator_tesim", "Author"],
-        ["part_of_tesim", "Part of"],
-        ["subject_tesim", "Subject"],
-        ["source_tesim", "Source"]
-      ].each do |field, label|
-        context field.to_s do
-          let(:given_field) { field }
-
-          it { is_expected.to eq(label) }
-        end
-      end
-    end
-
     describe 'solr dictionaries' do
       it 'does not specified spellcheck.dictionaries' do
         # rubocop:disable Layout/LineLength


### PR DESCRIPTION
# Story

Refs https://github.com/notch8/adventist_knapsack/issues/905

Removes dog biscuits definition of terms showing on the catalog page, and defines them explicitly in the catalog controller decorator.

Adds missing translations for the new terms to the locale file.

Sets flexible off for dev environment.

# Expected Behavior Before Changes

Clicking on a faceted item displayed the catalog page rather than a faceted search.

# Expected Behavior After Changes

- Catalog facets for items appropriately do a faceted search

# Screenshots / Video

<details>
<summary>Catalog Page</summary>

[recorded (20).webm](https://github.com/user-attachments/assets/40c8a5c2-8d00-4419-b6f9-04699752bf57)

</details>

# Notes
