### PR TITLE
🎁 Exclude collection from catalog search results

### DIFF
--- a/config/metadata/collection_resource.yaml
+++ b/config/metadata/collection_resource.yaml
@@ -516,3 +516,15 @@ attributes:
     index_keys:
     - proxy_depositor_ssi
     predicate: http://scholarsphere.psu.edu/ns#proxyDepositor
+  hide_from_catalog_search:
+    type: string
+    multiple: false
+    form:
+      display: false
+      required: false
+      primary: false
+      multiple: false
+    predicate: https://hykucommons.org/terms/hide_from_catalog_search
+    index_keys:
+    - hide_from_catalog_search_bsi
+    - hide_from_catalog_search_tesim

--- a/spec/search_builders/adv_search_builder_spec.rb
+++ b/spec/search_builders/adv_search_builder_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe AdvSearchBuilder do
         highlight_search_params
         show_parents_only
         include_allinson_flex_fields
+        filter_hidden_collections
       ]
     end
 


### PR DESCRIPTION
This commit updates the submodule that will add the ability to exclude a collection from the catalog search results.

A checkbox to `Hide from catalog search` is added to the Discovery tab of the collection edit form. Checking the box will set the `hide_from_catalog_search` attribute on the CollectionResource to true which will filter it from the search results.

The `hide_from_catalog_search` attribute is added to the collection resource metadata.

Ref:
- https://github.com/notch8/adventist_knapsack/issues/892
