### PR TITLE
fix-chart-yaml-redis-image

### DIFF
--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -475,8 +475,8 @@ postgresql:
   enabled: false
 redis:
   image:
-  repository: bitnamilegacy/redis
-  tag: 7.0.2-debian-11-r13
+    repository: bitnamilegacy/redis
+    tag: 7.0.2-debian-11-r13
   architecture: standalone
   cluster:
     enabled: false


### PR DESCRIPTION
Update the chart to have correct yaml formatting for bitnami redis image update



deploy fails due to not correct bitnami image due to invalid formatting of yaml in the deploy chart values file.