### PR TITLE
update-env-var-syntax

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -226,7 +226,7 @@ extraEnvVars: &envVars
   - name: SERVERLESS_SPLIT_SQS_URL
     value: sqs://us-east-1.amazonaws.com/031107666127/space-stone-production-split-ocr-thumbnail/
   - name: SERVERLESS_TEMPLATE
-    value: "{{dir_parts[-1..-1]}}/{{ basename }}{{ extension }}"
+    value: "{{ `{{dir_parts[-1..-1]}}/{{ basename }}{{ extension }}` }}"
   - name: SERVERLESS_THUMBNAIL_DLQ
     value: https://sqs.us-east-1.amazonaws.com/031107666127/space-stone-production-thumbnail-dlq
   - name: SERVERLESS_THUMBNAIL_SQS_URL

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -325,7 +325,7 @@ extraDeploy:
                 command:
                   - sh
                   - -c
-                  - "db-wait.sh {{ include "hyrax.redis.host" . }}:6379"
+                  - "service-wait.sh {{ include "hyrax.redis.host" . }}:6379"
               {{- if .Values.worker.extraInitContainers }}
               {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
               {{- end }}

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -452,7 +452,7 @@ postgresql:
 redis:
   image:
     repository: bitnamilegacy/redis
-    tag: 7.0.2-debian-11-r13
+    tag: 7.0.2-debian-11-r9
   architecture: standalone
   cluster:
     enabled: false

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -349,7 +349,7 @@ extraDeploy:
               command:
                 - sh
                 - -c
-                - "db-wait.sh {{ include "hyrax.redis.host" . }}:6379"
+                - "service-wait.sh {{ include "hyrax.redis.host" . }}:6379"
             {{- if .Values.worker.extraInitContainers }}
             {{- toYaml .Values.worker.extraInitContainers | nindent 8 }}
             {{- end }}

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -244,7 +244,7 @@ extraEnvVars: &envVars
   - name: SERVERLESS_SPLIT_SQS_URL
     value: sqs://us-east-1.amazonaws.com/031107666127/space-stone-production-split-ocr-thumbnail/
   - name: SERVERLESS_TEMPLATE
-    value: "{{dir_parts[-1..-1]}}/{{ basename }}{{ extension }}"
+    value: "{{ `{{dir_parts[-1..-1]}}/{{ basename }}{{ extension }}` }}"
   - name: SERVERLESS_THUMBNAIL_DLQ
     value: https://sqs.us-east-1.amazonaws.com/031107666127/space-stone-production-thumbnail-dlq
   - name: SERVERLESS_THUMBNAIL_SQS_URL

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -476,7 +476,7 @@ postgresql:
 redis:
   image:
     repository: bitnamilegacy/redis
-    tag: 7.0.2-debian-11-r13
+    tag: 7.0.2-debian-11-r9
   architecture: standalone
   cluster:
     enabled: false


### PR DESCRIPTION
## Story

This PR makes three key updates:

1. **Fix Go template evaluation error**  
   - Deployment was failing because the env var `SERVERLESS_TEMPLATE` was being evaluated as a Go template.  
   - The value was:  
     ```yaml
     "{{dir_parts[-1..-1]}}/{{ basename }}{{ extension }}"
     ```  
   - To prevent Go from interpreting it, the value is now wrapped in `{{` `}}` to escape templating.

2. **Update Redis Bitnami image**  
   - Switches to the latest available Bitnami Legacy Redis image:  
     ```
     7.0.2-debian-11-r9
     ```

3. **Align aux worker deploy with chart version 3.7.1**  
   - Updates the startup script used by aux worker.  
   - `db-wait.sh` is replaced with `service-wait.sh` to match changes introduced in chart `3.7.1`.

---

✅ Fixes deployment errors  
✅ Keeps Redis on a supported image version  
✅ Ensures consistency with the updated Helm chart  
