### PR TITLE
HOTFIX - DO NOT MERGE!  Change nested collection query to use POST

### DIFF
--- a/app/services/hyrax/collections/nested_collection_query_service_decorator.rb
+++ b/app/services/hyrax/collections/nested_collection_query_service_decorator.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 5.0 to force POST for nested collection queries
+# @todo - remove when Hyrax supports POST for nested collection queries
+module Hyrax
+  module Collections
+    ##
+    # A query service handling nested collection queries.
+    module NestedCollectionQueryServiceDecorator
+      extend ActiveSupport::Concern
+
+      class_methods do
+        private
+
+        def query_solr(collection:, access:, scope:, limit_to_id:, nest_direction:)
+          scope.blacklight_config.http_method = :post
+          super
+        end
+      end
+    end
+  end
+end
+
+Hyrax::Collections::NestedCollectionQueryService.prepend(Hyrax::Collections::NestedCollectionQueryServiceDecorator)


### PR DESCRIPTION
The Nested Collection Controller is not based on catalog controller, so it does not inherit the POST behavior we added there. This causes the `parent_and_child_can_nest?` to do a GET request, which fails when too many ids are included in the request. 

In this fix, we add an explicit setting of `http_method` prior to doing this query. This fix should be moved to `Hyrax::Collections::NestedCollectionQueryService`, and removed here once that is complete.

This is a temporary override until Hyrax code supporting POST for nested collection queries is brought forward, so it should not be merged.

